### PR TITLE
Automatic update of Microsoft.VisualStudio.Azure.Containers.Tools.Targets to 1.0.2073426

### DIFF
--- a/NewsletterCurator.Web/NewsletterCurator.Web.csproj
+++ b/NewsletterCurator.Web/NewsletterCurator.Web.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.4" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.0.1916590" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.0.2073426" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="1.0.163" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` to `1.0.2073426` from `1.0.1916590`
`Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.0.2073426` was published at `2018-09-28T23:58:03Z`, 14 days ago

1 project update:
Updated `NewsletterCurator.Web\NewsletterCurator.Web.csproj` to `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` `1.0.2073426` from `1.0.1916590`

[Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.0.2073426 on NuGet.org](https://www.nuget.org/packages/Microsoft.VisualStudio.Azure.Containers.Tools.Targets/1.0.2073426)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
